### PR TITLE
Update plugin.yml and linter

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,8 +5,8 @@ steps:
         run: tests
   - label: ":sparkles: lint"
     plugins:
-      plugin-linter#v1.0.0:
-        name: thedyrt/change-directory
+      plugin-linter#v2.0.0:
+        id: thedyrt/change-directory
   - label: ":shell: Shellcheck"
     plugins:
       shellcheck#v1.0.1:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
       - ".:/plugin:ro"
   lint:
     image: buildkite/plugin-linter
-    command: ['--name', 'thedyrt/change-directory']
+    command: ['--id', 'thedyrt/change-directory']
     volumes:
       - ".:/plugin:ro"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,4 +1,4 @@
-name: change-directory
+name: Change Directory
 description: Changes the working directory before running command
 author: https://github.com/reidab
 requirements: []


### PR DESCRIPTION
We've made some changes to plugin.yml which means we're recommending plain English plugin names (for a future plugin directory), and I've renamed the --name param of the linter to --id to avoid confusion (buildkite-plugins/buildkite-plugin-linter#15).

This updates the sauce connect plugin with the new conventions.